### PR TITLE
fix: use MSBuild target for IsWindows/IsLinux properties, not current OS

### DIFF
--- a/VTFLib.NET/VTFLib.NET.csproj
+++ b/VTFLib.NET/VTFLib.NET.csproj
@@ -4,9 +4,17 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">true</IsWindows> 
-    <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'true'">true</IsLinux> 
+
+    <!-- Required, otherwise $(RuntimeIdentifier) is never defined-->
+    <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
+
+    <!-- Use RID if given, otherwise current OS -->
+    <IsWindows Condition="'$(RuntimeIdentifier)' != '' and $(RuntimeIdentifier.StartsWith('win'))">true</IsWindows>
+    <IsWindows Condition="'$(RuntimeIdentifier)' == '' and $([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows))) == 'true'">true</IsWindows>
+    <IsLinux Condition="'$(RuntimeIdentifier)' != '' and $(RuntimeIdentifier.StartsWith('linux'))">true</IsLinux>
+    <IsLinux Condition="'$(RuntimeIdentifier)' == '' and $([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux))) == 'true'">true</IsLinux>
   </PropertyGroup>
+
   <PropertyGroup Condition="'$(IsWindows)'=='true'">
     <DefineConstants>WINDOWS</DefineConstants>
   </PropertyGroup>
@@ -31,5 +39,5 @@
     <None Update="libvtflib.so">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-  </ItemGroup >
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
When Lumper's build job ran for Windows, the `IsLinux` condition was true, since `System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform` refers to the runner's OS, which is obviously Linux. This sets `IsWindows` and `IsLinux` conditionally based on whether a runtime identifier is provided: `dotnet build` will set based on current OS, `dotnet build -r win-x64` will be Windows regardless of the runner's OS.